### PR TITLE
Исправил ворнинг в тестах на tests_runner

### DIFF
--- a/tests_runner/tests/cases/lmbTestPHPUnitTestCaseAdapterTest.class.php
+++ b/tests_runner/tests/cases/lmbTestPHPUnitTestCaseAdapterTest.class.php
@@ -33,7 +33,7 @@ class lmbTestPHPUnitTestCaseAdapterTest extends lmbTestRunnerBase
   {
     $this->_mustBePassed('$this->assertRegexp("/bAr/i", "foo-bar-baz");');
     $this->_mustBeFailed('$this->assertRegexp("/bug/", "foo-bar-baz");');
-    $this->_mustBeFailed('$this->assertRegexp(42, 0, "custom message");', 'custom message');
+    $this->_mustBeFailed('$this->assertRegexp("/42/", 0, "custom message");', 'custom message');
   }
 
   function testError()


### PR DESCRIPTION
Странно, что на билд-сервере этот баг не вышел...
Кто-нибудь знает как удалить эти мерджи? А то 10 коммитов вместо одного :(
