### PR TITLE
Fix bug: Wrong file path to user-defined macro tags

### DIFF
--- a/macro/tests/cases/lmbBaseMacroTest.class.php
+++ b/macro/tests/cases/lmbBaseMacroTest.class.php
@@ -78,7 +78,7 @@ class lmbBaseMacroTest extends UnitTestCase
       'forcecompile' => true,
       'forcescan' => true,
       'tpl_scan_dirs' =>  array($this->tpl_dir),
-      'tags_scan_dirs' => array('src/macro', 'limb/*/src/macro', 'limb/macro/src/tags'),
+      'tags_scan_dirs' => array('src/tags', 'src/macro', 'limb/*/src/macro', 'limb/macro/src/tags'),
       'filters_scan_dirs' => array('src/filters', 'limb/*/src/macro', 'limb/macro/src/filters')
     );
     return new lmbMacroConfig($config);


### PR DESCRIPTION
По умолчанию в конфиге limb/view/settings/macro.conf.php папка с тегами macro у пользователя: src/macro, но в тестах указана папка src/tags. Мне кажется, было бы более правильным использовать один путь в разных пакетах (View и Macro).

Считывать путь с конфигурационного файла менее удобно, тк. тогда у тестов макро появиться зависимость на пакета view. (Чего сейчас нет, судя по документу http://wiki.limb-project.com/2011.1/doku.php?id=limb3:ru:packages)

Мотивация: упростить написание тестов для тегов макро новичками; устранить конфликт адресов внутри фреймворка.
