### PR TITLE
Fixed inheritance field value for finding kind-related objects.

### DIFF
--- a/active_record/src/lmbActiveRecord.class.php
+++ b/active_record/src/lmbActiveRecord.class.php
@@ -1832,7 +1832,7 @@ class lmbActiveRecord extends lmbObject
 
   protected function _getInheritanceCriteria()
   {
-    return lmbSQLCriteria::like($this->getInheritanceField(), $this->_getInheritancePath() . "%");
+    return lmbSQLCriteria::like($this->getTableName() . '.' . $this->getInheritanceField(), $this->_getInheritancePath() . "%");
   }
 
   protected function _getInheritancePath()

--- a/active_record/tests/cases/.fixture/init_tests.mysqli
+++ b/active_record/tests/cases/.fixture/init_tests.mysqli
@@ -25,6 +25,15 @@ CREATE TABLE `test_one_table_typed_object` (
   PRIMARY KEY  (`id`)
 ) ENGINE=MEMORY DEFAULT CHARSET=utf8;
 
+DROP TABLE IF EXISTS `related_test_one_table_typed_object`;
+CREATE TABLE `related_test_one_table_typed_object` (
+  `id` bigint(11) NOT NULL auto_increment,
+  `title` varchar(50) default NULL,
+  `related_id` bigint(11) NOT NULL,
+  `kind` varchar(255) NOT NULL,
+  PRIMARY KEY  (`id`)
+) ENGINE=MEMORY DEFAULT CHARSET=utf8;
+
 DROP TABLE IF EXISTS `course_for_typed_test`;
 CREATE TABLE `course_for_typed_test` (
  `id` int(11) NOT NULL auto_increment,

--- a/active_record/tests/cases/lmbARSubclassingTest.class.php
+++ b/active_record/tests/cases/lmbARSubclassingTest.class.php
@@ -151,6 +151,34 @@ class lmbARSubclassingTest extends lmbARBaseTestCase
     $this->assertEqual($records[1]->title, $valid_object2->title);
   }
 
+  function testFindingObjectByKind()
+  {
+    $parent = new OneTableTypedObject();
+    $parent->save();
+
+    $related_object  = new RelatedOneTableTypedObject();
+    $related_object->save();
+
+    $child = new OneTableTypedObjectChild();
+    $child->save();
+
+    $related_to_child = new RelatedOneTableTypedObjectChild();
+    $related_to_child->save();
+    
+    $child->addToRelatedObjects($related_to_child);
+    $related_to_child->setPrimaryObject($child);
+
+    $child->save();
+    $related_to_child->save();
+
+    $join = array('primary_object');
+    $sort = array('primary_object.id' => 'ASC');
+    
+    $objects = RelatedOneTableTypedObjectChild::find(array('join' => $join, 'sort' => $sort));
+
+    $this->assertEqual($objects->count(), 1);
+  }
+
   function testTypedRelationFind()
   {
     $course = new CourseForTestForTypedLecture();

--- a/active_record/tests/cases/lmbARTestingObjectMother.class.php
+++ b/active_record/tests/cases/lmbARTestingObjectMother.class.php
@@ -22,6 +22,38 @@ class LazyTestOneTableObject extends lmbActiveRecord
   protected $_lazy_attributes = array('annotation', 'content');
 }
 
+class OneTableTypedObject extends lmbActiveRecord
+{
+  protected $_db_table_name = 'test_one_table_typed_object';
+
+  protected $_has_many = array('related_parents' => array('field' => 'related_id',  
+                                                          'class' => 'RelatedOneTableTypedObject'));    
+}
+
+class RelatedOneTableTypedObject extends lmbActiveRecord
+{
+  protected $_db_table_name = 'related_test_one_table_typed_object';
+
+  protected $_many_belongs_to = array('primary_parent' => array('field' => 'related_id',
+                                                                'class' => 'OneTableTypedObject'));  
+}
+
+class OneTableTypedObjectChild extends OneTableTypedObject
+{
+  protected $_db_table_name = 'test_one_table_typed_object';
+  
+  protected $_has_many = array('related_objects' => array('field' => 'related_id',  
+                                                          'class' => 'RelatedOneTableTypedObjectChild'));  
+}
+
+class RelatedOneTableTypedObjectChild extends lmbActiveRecord
+{
+  protected $_db_table_name = 'related_test_one_table_typed_object';
+
+  protected $_many_belongs_to = array('primary_object' => array('field' => 'related_id',
+                                                                'class' => 'OneTableTypedObjectChild'));    
+}
+
 class PersonForTest extends lmbActiveRecord
 {
   public $save_count = 0;


### PR DESCRIPTION
Previously while doing ActiveRecord::find among inherited object there was an sql-error "`kind` field is ambigous".
Commit changes searching options so that a particular `table.field` value is inserted in the sql query.
Test is included.
