### PR TITLE
Pg session store

### DIFF
--- a/docs/en/architecture/db_schema.md
+++ b/docs/en/architecture/db_schema.md
@@ -13,7 +13,7 @@ The other tables are optional. The example DB schema contains several other tabl
 
 Table | Description
 ------|------------
-sys_session	| Stores session data. This table is required if you want to keep your session data in DB
+lmb_session	| Stores session data. This table is required if you want to keep your session data in DB
 sys_tree | Stores data about tree structure (materialized path algorithm). This table contains also hierarhies and has no idea how these hierarhies are used. You can remove this table for simple projects e.g. file-based wiki or simple news project.
 sys_object_to_node | Contains information how limb-object's are connected to tree nodes
 sys_service	| Contains list of Services. sys_service and sys_object_to_service tables are required only if some of your limb-objects will be connected to Services.

--- a/session/docs/ru/session.md
+++ b/session/docs/ru/session.md
@@ -22,12 +22,12 @@ lmbSessionDbStorage — класс, который позволяет храни
 
 SQL-код структуры таблицы, где хранятся сессионные данные показан ниже:
 
-    CREATE TABLE `sys_session` (                              
-      `session_id` VARCHAR(50) NOT NULL DEFAULT '',           
-      `session_data` BLOB NOT NULL,                           
-      `last_activity_time` BIGINT(11) UNSIGNED DEFAULT NULL,  
-      PRIMARY KEY  (`session_id`)                            
-    ) ENGINE=MyISAM DEFAULT CHARSET=utf8 
+    CREATE TABLE `lmb_session` (
+      `session_id` VARCHAR(50) NOT NULL DEFAULT '',
+      `session_data` BLOB NOT NULL,
+      `last_activity_time` BIGINT(11) UNSIGNED DEFAULT NULL,
+      PRIMARY KEY  (`session_id`)
+    ) ENGINE=MyISAM DEFAULT CHARSET=utf8
 
 lmbSessionDbStorage в методе installStorage() регистрирует в качестве обработчиков сессионных сообщений свои методы, такие как sessionStart(), sessionRead(), sessionWrite() и т.д.
 

--- a/session/src/lmbSessionDbStorage.class.php
+++ b/session/src/lmbSessionDbStorage.class.php
@@ -2,9 +2,9 @@
 /*
  * Limb PHP Framework
  *
- * @link http://limb-project.com 
+ * @link http://limb-project.com
  * @copyright  Copyright &copy; 2004-2009 BIT(http://bit-creative.com)
- * @license    LGPL http://www.gnu.org/copyleft/lesser.html 
+ * @license    LGPL http://www.gnu.org/copyleft/lesser.html
  */
 lmb_require('limb/session/src/lmbSessionStorage.interface.php');
 lmb_require('limb/dbal/src/criteria/lmbSQLFieldCriteria.class.php');
@@ -108,6 +108,7 @@ class lmbSessionDbStorage implements lmbSessionStorage
     $data = array('last_activity_time' => time(),
                   'session_data' => $value);
 
+    $this->db->begin();
     if($rs->count() > 0)
       $this->db->update('lmb_session', $data, $crit);
     else
@@ -115,6 +116,7 @@ class lmbSessionDbStorage implements lmbSessionStorage
       $data['session_id'] = "{$session_id}";
       $this->db->insert('lmb_session', $data, null);
     }
+    $this->db->commit();
   }
 
   /**
@@ -124,8 +126,10 @@ class lmbSessionDbStorage implements lmbSessionStorage
    */
   function storageDestroy($session_id)
   {
+    $this->db->begin();
     $this->db->delete('lmb_session',
                       new lmbSQLFieldCriteria('session_id', $session_id));
+    $this->db->commit();
   }
 
   /**
@@ -139,8 +143,10 @@ class lmbSessionDbStorage implements lmbSessionStorage
     if($this->max_life_time)
       $max_life_time = $this->max_life_time;
 
+    $this->db->begin();
     $this->db->delete('lmb_session',
                       new lmbSQLFieldCriteria('last_activity_time', time() - $max_life_time, lmbSQLFieldCriteria::LESS));
+    $this->db->commit();
   }
 }
 

--- a/session/src/lmbSessionDbStorage.class.php
+++ b/session/src/lmbSessionDbStorage.class.php
@@ -34,10 +34,11 @@ class lmbSessionDbStorage implements lmbSessionStorage
   /**
    *  Constructor.
    *  @param lmbDbConnection database connection object
-   *  @param integer maximum session life time
    */
-  function __construct($db_connection, $max_life_time = null)
+  function __construct($db_connection)
   {
+    $max_life_time = lmb_env_get('LIMB_SESSION_DB_MAX_LIFE_TIME');
+
     $this->max_life_time = $max_life_time;
 
     $this->db = new lmbSimpleDb($db_connection);

--- a/session/tests/cases/lmbSessionDbStorageTest.class.php
+++ b/session/tests/cases/lmbSessionDbStorageTest.class.php
@@ -2,9 +2,9 @@
 /*
  * Limb PHP Framework
  *
- * @link http://limb-project.com 
+ * @link http://limb-project.com
  * @copyright  Copyright &copy; 2004-2009 BIT(http://bit-creative.com)
- * @license    LGPL http://www.gnu.org/copyleft/lesser.html 
+ * @license    LGPL http://www.gnu.org/copyleft/lesser.html
  */
 lmb_require('limb/session/src/lmbSessionDbStorage.class.php');
 lmb_require('limb/dbal/src/lmbSimpleDb.class.php');
@@ -183,7 +183,8 @@ class lmbSessionDbStorageTest extends UnitTestCase
 
   function testStorageGcUseSettedMaxLifeTime()
   {
-    $driver = new lmbSessionDbStorage($this->conn, $max_life_time = 500);
+    lmb_env_setor('LIMB_SESSION_DB_MAX_LIFE_TIME', 500);
+    $driver = new lmbSessionDbStorage($this->conn);
 
     $this->db->insert('lmb_session',
                           array('session_id' => "whatever",

--- a/web_app/docs/ru/web_app/session.md
+++ b/web_app/docs/ru/web_app/session.md
@@ -5,7 +5,7 @@
     $session = lmbToolkit :: instance()->getSession();
     $session->set('my_var', $value); // Поставить значение в сессию
     $var = $session->get('my_var');  // Получить значение из сессии
- 
+
     $session->foo = $value; // Поставить значение в сессию
     $bar = $session->foo;  // Получить значение из сессии
 
@@ -37,7 +37,7 @@ lmbSessionStartupFilter опирается на константу **LIMB_SESSIO
 
 Для хранения сессионных данных в базе данных используется таблице **sys_session** со следующей структурой:
 
-    CREATE TABLE `sys_session` (
+    CREATE TABLE `lmb_session` (
       `session_id` VARCHAR(50) NOT NULL DEFAULT '',
       `session_data` BLOB NOT NULL,
       `last_activity_time` BIGINT(11) UNSIGNED DEFAULT NULL,

--- a/web_app/src/filter/lmbSessionStartupFilter.class.php
+++ b/web_app/src/filter/lmbSessionStartupFilter.class.php
@@ -27,10 +27,11 @@ class lmbSessionStartupFilter implements lmbInterceptingFilter
    * @see lmbInterceptingFilter :: run()
    * @uses LIMB_SESSION_USE_DB_DRIVER
    */
-  function run($filter_chain, $session_in_db = false, $session_in_db_lifetime = null)
+  function run($filter_chain)
   {
+    $session_in_db = defined('LIMB_SESSION_USE_DB_DRIVER') ? LIMB_SESSION_USE_DB_DRIVER : false;
     if($session_in_db)
-      $storage =  $this->_createDBSessionStorage($session_in_db_lifetime);
+      $storage =  $this->_createDBSessionStorage();
     else
       $storage =  $this->_createNativeSessionStorage();
 
@@ -50,8 +51,10 @@ class lmbSessionStartupFilter implements lmbInterceptingFilter
    * Creates object of {@link lmbSessionDbStorage} class.
    * @see lmbInterceptingFilter :: run()
    */
-  protected function _createDBSessionStorage($lifetime)
+  protected function _createDBSessionStorage()
   {
+    $lifetime = defined('LIMB_SESSION_DB_MAX_LIFE_TIME') ? LIMB_SESSION_DB_MAX_LIFE_TIME : null;
+
     lmb_require('limb/session/src/lmbSessionDbStorage.class.php');
     $db_connection = lmbToolkit :: instance()->getDefaultDbConnection();
     return new lmbSessionDbStorage($db_connection, $lifetime);

--- a/web_app/src/filter/lmbSessionStartupFilter.class.php
+++ b/web_app/src/filter/lmbSessionStartupFilter.class.php
@@ -29,7 +29,8 @@ class lmbSessionStartupFilter implements lmbInterceptingFilter
    */
   function run($filter_chain)
   {
-    $session_in_db = defined('LIMB_SESSION_USE_DB_DRIVER') ? LIMB_SESSION_USE_DB_DRIVER : false;
+    $session_in_db = lmb_env_get('LIMB_SESSION_USE_DB_DRIVER', false);
+
     if($session_in_db)
       $storage =  $this->_createDBSessionStorage();
     else
@@ -53,11 +54,9 @@ class lmbSessionStartupFilter implements lmbInterceptingFilter
    */
   protected function _createDBSessionStorage()
   {
-    $lifetime = defined('LIMB_SESSION_DB_MAX_LIFE_TIME') ? LIMB_SESSION_DB_MAX_LIFE_TIME : null;
-
     lmb_require('limb/session/src/lmbSessionDbStorage.class.php');
     $db_connection = lmbToolkit :: instance()->getDefaultDbConnection();
-    return new lmbSessionDbStorage($db_connection, $lifetime);
+    return new lmbSessionDbStorage($db_connection);
   }
 }
 


### PR DESCRIPTION
Обернул сохранение сессий в транзакции. Без этого не работает c postgre.
В добавление фильтра использовал константы LIMB_SESSION_USE_DB_DRIVER и LIMB_SESSION_DB_MAX_LIFE_TIME для определения хранилища и максимального времени жизни соответственно.
В документации указал правильную таблицу для хранения сессий.
